### PR TITLE
Fixing ARGs and jobs.args

### DIFF
--- a/logstash_formatter/__init__.py
+++ b/logstash_formatter/__init__.py
@@ -9,6 +9,7 @@ import datetime
 import traceback as tb
 import json
 
+
 def _default_json_default(obj):
     """
     Coerce everything to strings.
@@ -18,6 +19,7 @@ def _default_json_default(obj):
         return obj.isoformat()
     else:
         return str(obj)
+
 
 class LogstashFormatter(logging.Formatter):
     """
@@ -40,7 +42,6 @@ class LogstashFormatter(logging.Formatter):
         :param json_default: Default JSON representation for unknown types,
                              by default coerce everything to a string
         """
-
         if fmt is not None:
             self._fmt = json.loads(fmt)
         else:
@@ -99,6 +100,19 @@ class LogstashFormatter(logging.Formatter):
             fields.pop(tag, '')
 
         logr = self.defaults.copy()
+        if fields.get("args"):
+            if isinstance(fields["args"], list):
+                new_list = [repr(arg) for arg in fields["args"]]
+                fields["args"] = new_list
+            else:
+                fields["args"] = [repr(fields["args"])]
+
+        if fields.get("job", {}).get("args"):
+            if isinstance(fields["job"]["args"], list):
+                new_list = [repr(arg) for arg in fields["job"]["args"]]
+                fields["job"]["args"] = new_list
+            else:
+                fields["job"]["args"] = [repr(fields["job"]["args"])]
 
         logr.update({'@message': msg,
                      '@timestamp': datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S.%fZ'),

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def read(*parts):
                        encoding="utf-8").read()
 
 setup(name='logstash-formatter',
-      version='1.0.0',
+      version='1.0.1',
       description='JSON formatter meant for logstash',
       long_description=read('README.rst'),
       url='https://github.com/exoscale/python-logstash-formatter',


### PR DESCRIPTION
fixing a bug where we were sending mixed data type arrays to elasticsearch. Elastic search can't do that. messages were being dropped

also leave code better than you found it edits