### PR TITLE
making it not mess up the original dict

### DIFF
--- a/logstash_formatter/__init__.py
+++ b/logstash_formatter/__init__.py
@@ -8,6 +8,7 @@ import socket
 import datetime
 import traceback as tb
 import json
+import copy
 
 
 def _default_json_default(obj):
@@ -71,7 +72,7 @@ class LogstashFormatter(logging.Formatter):
         fields.
         """
 
-        fields = record.__dict__.copy()
+        fields = copy.deepcopy(record.__dict__)
 
         if isinstance(record.msg, dict):
             fields.update(record.msg)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def read(*parts):
                        encoding="utf-8").read()
 
 setup(name='logstash-formatter',
-      version='1.0.2',
+      version='1.0.3',
       description='JSON formatter meant for logstash',
       long_description=read('README.rst'),
       url='https://github.com/exoscale/python-logstash-formatter',


### PR DESCRIPTION
This fixes a bug which would take the original jobs dict and overwrite it in the calling function thus a call like
 ```
        logging.error(
            '%s: %s',
            'Retrying' if retry_at else 'Failed',
            str(exception),
            exc_info=exception_tb or False,
            extra={
                'job': job_dump
            }
        )
        if retry_at:
            self._delayed.put(retry_at, json.dumps(job_dump), job.lookup_key)
        else:
            self._update_stats(job, 'fails') 
```
 would end up in job_dump being whatever the logger modifies it to be